### PR TITLE
Create filter for custom post types

### DIFF
--- a/includes/pb-posttype.php
+++ b/includes/pb-posttype.php
@@ -6,22 +6,27 @@
 namespace Pressbooks\PostType;
 
 /**
- * List our post_types
- *
- * @return array
- */
+*  Filter to allow users to add additional custom post types to the list of permitted post types.
+*
+* @Since 3.9.9
+*
+* @param array $posttypes
+*
+* @return array
+*/
 function list_post_types() {
-
-	return array(
+	
+	$posttypes = apply_filters('pb_supported_post_types', array(
 		'metadata',
 		'part',
 		'chapter',
 		'front-matter',
 		'back-matter',
 		'custom-css',
-	);
-}
+	));
+	return $posttypes;
 
+}
 
 /**
  * Loads Chapter, Part, Front Matter, Back Matter, and Metadata custom post types


### PR DESCRIPTION
Added a filter to the list of custom post types allowed by Pressbooks.
Should help resolve https://github.com/pressbooks/pressbooks/issues/546.